### PR TITLE
Add asciinema .cast file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,50 @@ Custom ASCII frames can be loaded from text files. Each frame is separated by `-
 
 An example frame file (`example-frames.txt`) is included with a simple character animation. You can use it as a starting point for your own custom animations.
 
+## Asciinema .cast File Support
+
+Gophetch now supports asciinema `.cast` files, allowing you to use terminal recordings as animations. This opens up a world of possibilities for creating dynamic, realistic terminal animations.
+
+### Creating .cast Files
+
+You can create `.cast` files using the `asciinema` tool:
+
+```bash
+# Record a terminal session
+asciinema rec my-animation.cast
+
+# Play it back to test
+asciinema play my-animation.cast
+
+# Use it with Gophetch
+./gophetch my-animation.cast
+```
+
+### .cast File Features
+
+- **Automatic frame extraction**: Gophetch automatically extracts frames from the continuous terminal output
+- **ANSI sequence processing**: Handles terminal colors, cursor movements, and formatting using regex-based processing
+- **Timing preservation**: Maintains the original timing relationships from the recording
+- **Standard format**: Works with any asciinema-compatible recording
+- **Cross-platform**: Works on all supported platforms (Windows, Linux, macOS, Android/Termux)
+
+### Supported File Formats
+
+Gophetch now supports two animation formats:
+
+1. **Custom Frame Files** (`.txt`, `.frames`): Traditional ASCII art frames separated by `---FRAME---`
+2. **Asciinema .cast Files** (`.cast`): Terminal recordings with automatic frame extraction
+
+### Example Use Cases
+
+- Terminal demos and tutorials
+- Command-line tool showcases
+- Interactive script demonstrations
+- Real-time data visualization
+- Terminal-based games and applications
+- Live coding sessions
+- System monitoring displays
+
 ## Controls
 
 - `q` or `Ctrl+C` - Exit application
@@ -138,6 +182,8 @@ An example frame file (`example-frames.txt`) is included with a simple character
 ## Future Enhancements
 
 - Change default config location to OS appropriate locations (e.g., `~/.config/gophetch/` on Linux/macOS, `%APPDATA%\gophetch\` on Windows)
+- Enhanced ANSI sequence processing for better .cast file rendering
+- Support for custom frame extraction intervals in .cast files
 
 ## License
 


### PR DESCRIPTION
## Description
This PR adds comprehensive support for asciinema `.cast` files, allowing users to use terminal recordings as animations in Gophetch. This opens up new possibilities for creating dynamic, realistic terminal animations from actual terminal sessions.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing
- [x] Tested on Windows
- [ ] Tested on Linux
- [ ] Tested on macOS
- [ ] Tested on Android/Termux
- [x] Tested with custom frame files (if applicable)
- [x] Tested with different frame rates
- [x] Verified graceful shutdown with Ctrl+C

## Changes Made
- **New Functions:**
  - `LoadFramesFromCastFile()`: Parses asciinema .cast files and extracts frames
  - `processANSISequences()`: Efficiently removes ANSI escape sequences using regex
  - Added `CastHeader` and `CastEvent` structs for .cast file parsing

- **Modified Functions:**
  - Updated `main()` function to detect and handle .cast files
  - Enhanced frame loading logic to support both custom frames and .cast files

- **New Features:**
  - Automatic frame extraction every 100ms from continuous terminal output
  - Regex-based ANSI sequence processing for clean text extraction
  - Cross-platform support for all asciinema-compatible recordings
  - Backward compatibility with existing frame file format

- **Configuration Changes:**
  - Updated frame file detection to include `.cast` extension
  - Enhanced error handling and fallback mechanisms

## Screenshots
N/A - This is a terminal-based application. The feature was tested with a sample .cast file and successfully extracted 82 frames.

## Related Issues
N/A - This is a new feature request implementation.

## Additional Notes
- The implementation uses compiled regex patterns for optimal performance when processing ANSI sequences
- Frame extraction is configurable (currently set to 100ms intervals) and could be made user-configurable in future versions
- The parser handles malformed .cast files gracefully by skipping invalid entries
- All existing functionality remains unchanged - this is purely additive
- Successfully tested with a real asciinema recording containing terminal interactions, chat interface, and various ANSI sequences